### PR TITLE
Use curly apostrophes and quotation marks

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@
           <div class="govuk-grid-row govuk-!-margin-bottom-9 govuk-flip">
             <div class="govuk-grid-column-one-half">
               <h3 class="govuk-heading-m govuk-!-margin-top-2">Public services fit for the modern age</h3>
-              <p class="govuk-body">In the digital age, citizens expect public services to "just work". Using GOV.UK Digital Service Platforms helps your organisation build services that are easy to use, efficient and save the public money.</p>
+              <p class="govuk-body">In the digital age, citizens expect public services to “just work”. Using GOV.UK Digital Service Platforms helps your organisation build services that are easy to use, efficient and save the public money.</p>
             </div>
             <div class="govuk-grid-column-one-half govuk-container-img-right">
               <picture class="govuk-img govuk-!-margin-bottom-4">
@@ -358,7 +358,7 @@
             </div>
             <div class="govuk-grid-column-one-half">
               <h3 class="govuk-heading-m govuk-!-margin-top-2">Making it easier to design and build public services</h3>
-              <p class="govuk-body">Many of GDS's tools need little or no technical expertise to implement successfully in your organisation. We want all of the public sector to be able to create effective, modern services.</p>
+              <p class="govuk-body">Many of GDS’s tools need little or no technical expertise to implement successfully in your organisation. We want all of the public sector to be able to create effective, modern services.</p>
               <ul class="govuk-list">
                 <li>
                   <a class="govuk-link" href="https://design-system.service.gov.uk/">GOV.UK Design System</a>


### PR DESCRIPTION
> “Smart quotes,” the correct quotation marks and apostrophes, are curly or sloped. […] straight quotes are a vestigial constraint from typewriters when using one key for two different marks helped save space on a keyboard.

– http://smartquotesforsmartpeople.com

This commit replaces the use of a straight single quotation mark as an apostrophe with the typographically-correct equivalent. It replaces the use of straight double quotes with the typographically-correct equivalent.