### PR TITLE
Update info about GOV⁠.⁠UK Forms

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,8 +158,7 @@
                   In development
                 </strong>
                 <h3 class="govuk-heading-m">Build a form</h3>
-                <p class="govuk-body">Create accessible online forms without needing technical knowledge.</p>
-                <p class="govuk-body">GOV.UK Forms is in development with selected government partners. You can register to get a notification when it's available for all of central government.</p>
+                <p class="govuk-body">GOV.UK Forms is a new platform that makes it easy to create accessible online forms for GOV.UK.</p>
                 <p class="govuk-body"><a href="https://www.forms.service.gov.uk/" class="govuk-link">Find out more about GOV.UK Forms</a></p>
               </div>
               <div class="govuk-grid-column-one-half">


### PR DESCRIPTION
Removed the lines about it being "in development with selected government partners" as they're no longer accurate.  Also tweaked the first line to make it clear that it's only for forms for GOV⁠.⁠UK at the moment. Feels important to say that here since other DSP products are available more widely.